### PR TITLE
SLING-7988 - Allow Analyzer include/exclude tasks by id, in order to enable specific Tasks in the Maven plugin

### DIFF
--- a/src/main/java/org/apache/sling/feature/maven/mojos/AnalyseFeaturesMojo.java
+++ b/src/main/java/org/apache/sling/feature/maven/mojos/AnalyseFeaturesMojo.java
@@ -19,6 +19,7 @@ package org.apache.sling.feature.maven.mojos;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Set;
 
 import org.apache.maven.artifact.handler.manager.ArtifactHandlerManager;
 import org.apache.maven.artifact.resolver.ArtifactResolver;
@@ -27,6 +28,7 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.sling.feature.ArtifactId;
 import org.apache.sling.feature.Feature;
@@ -51,6 +53,12 @@ public class AnalyseFeaturesMojo extends AbstractFeatureMojo {
     @Component
     ArtifactResolver artifactResolver;
 
+    @Parameter
+    Set<String> includeTasks;
+
+    @Parameter
+    Set<String> excludeTasks;
+
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         final ArtifactProvider am = new ArtifactProvider() {
@@ -69,7 +77,7 @@ public class AnalyseFeaturesMojo extends AbstractFeatureMojo {
             getLog().debug("Scanner successfully set up");
 
             getLog().debug("Setting up the Analyser...");
-            final Analyser analyser = new Analyser(scanner);
+            final Analyser analyser = new Analyser(scanner, includeTasks, excludeTasks);
             getLog().debug("Analyser successfully set up");
 
             getLog().debug("Retrieving Feature files...");


### PR DESCRIPTION
allow the users configure the Analyzer tasks by conventional include/exclude pattern

In that way, users can configure the plugin on that way:

```
      <plugin>
        <groupId>org.apache.sling</groupId>
        <artifactId>slingfeature-maven-plugin</artifactId>
        <version>${slingfeature-maven-plugin.version}</version>
        <executions>
          <execution>
            <id>analyze</id>
            <phase>validate</phase>
            <goals>
              <goal>analyse-features</goal>
            </goals>
            <configuration>
              <includeTasks>
                <includeTask>api-regions</includeTask>
              </includeTasks>
            </configuration>
          </execution>
          [...]
        </executions>
      </plugin>
```

please, before merging it, https://github.com/apache/sling-org-apache-sling-feature-analyser/pull/5 is required to be applied first!