### PR TITLE
SLING-8078 - New Analyser task which is able to detect Export-Package dependencies between regions

### DIFF
--- a/src/it/analyzer-apiregions-errors-detected/invoker.properties
+++ b/src/it/analyzer-apiregions-errors-detected/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+invoker.goals = clean org.apache.sling:slingfeature-maven-plugin:analyse-features validate
+invoker.buildResult = failure
+invoker.debug = true

--- a/src/it/analyzer-apiregions-errors-detected/pom.xml
+++ b/src/it/analyzer-apiregions-errors-detected/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+    agreements. See the NOTICE file distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file except in compliance with the
+    License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the
+    License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+    either express or implied. See the License for the specific language governing permissions
+    and limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.sling</groupId>
+  <artifactId>slingfeature-maven-plugin-test</artifactId>
+  <packaging>jar</packaging>
+  <version>1.0.0-SNAPSHOT</version>
+
+  <name>Apache Sling Features Maven plugin test</name>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <extensions>true</extensions>
+        <executions>
+          <execution>
+            <id>analyze</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>analyse-features</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <scans>
+            <scan>
+              <includes>**/*.json</includes>
+              <includeTasks>api-regions-dependencies</includeTasks>
+              <contextConfiguration>
+                <exporting-apis>my-global</exporting-apis>
+                <hiding-apis>my-deprecated</hiding-apis>
+              </contextConfiguration>
+            </scan>
+          </scans>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/it/analyzer-apiregions-errors-detected/src/main/features/errorsDetected.json
+++ b/src/it/analyzer-apiregions-errors-detected/src/main/features/errorsDetected.json
@@ -1,0 +1,23 @@
+{
+  "id":"org.apache.sling:slingfeature-maven-plugin-test:1.0.0-SNAPSHOT",
+  "bundles":[
+    {
+      "id":"org.apache.aries.versioning:org.apache.aries.versioning.checker:0.3.1",
+      "start-level":"20"
+    }
+  ],
+  "api-regions:JSON|false": [
+    {
+      "name": "my-global",
+      "exports": [
+        "org.apache.aries.versioning.check"
+      ]
+    },
+    {
+      "name": "my-deprecated",
+      "exports": [
+        "org.objectweb.asm"
+      ]
+    }
+  ]
+}

--- a/src/it/analyzer-apiregions-errors-detected/verify.bsh
+++ b/src/it/analyzer-apiregions-errors-detected/verify.bsh
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.io.*;
+import java.util.*;
+
+import org.codehaus.plexus.util.*;
+
+    boolean check() {
+        File file = new File(basedir, "build.log");
+        String log = FileUtils.fileRead(file);
+
+        if (log.indexOf("Bundle 'org.apache.aries.versioning:org.apache.aries.versioning.checker:0.3.1' (defined in feature 'org.apache.sling:slingfeature-maven-plugin-test:1.0.0-SNAPSHOT') declares 'org.apache.aries.versioning.check' in the 'Export-Package' header, enlisted in the 'my-global' region, which requires 'org.objectweb.asm' package that is in the 'my-deprecated' region") < 0) {
+            System.out.println( "FAILED!" );
+            return false;
+        }
+        return true;
+    }
+
+    try {
+      return check();
+    }
+    catch(Throwable t) {
+      t.printStackTrace();
+      return false;
+    }
+
+    return true;

--- a/src/main/java/org/apache/sling/feature/maven/mojos/AnalyseFeaturesMojo.java
+++ b/src/main/java/org/apache/sling/feature/maven/mojos/AnalyseFeaturesMojo.java
@@ -19,6 +19,7 @@ package org.apache.sling.feature.maven.mojos;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 import org.apache.maven.plugin.MojoExecutionException;
@@ -36,8 +37,6 @@ import org.apache.sling.feature.builder.ArtifactProvider;
 import org.apache.sling.feature.maven.ProjectHelper;
 import org.apache.sling.feature.scanner.Scanner;
 
-import edu.emory.mathcs.backport.java.util.Collections;
-
 /**
  * Analyse the feature.
  */
@@ -51,7 +50,6 @@ public class AnalyseFeaturesMojo extends AbstractIncludingFeatureMojo {
     @Parameter
     private List<Scan> scans;
 
-    @SuppressWarnings("unchecked")
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         List<Scan> list = scans;
@@ -83,8 +81,11 @@ public class AnalyseFeaturesMojo extends AbstractIncludingFeatureMojo {
         for (final Scan an : list) {
             try {
 
-                getLog().debug(MessageUtils.buffer().a("Setting up the ").strong("Analyser").a("...").toString());
-                final Analyser analyser = new Analyser(scanner, an.getIncludeTasks(), an.getExcludeTasks());
+                getLog().debug(MessageUtils.buffer().a("Setting up the ").strong("Analyser").a(" with following configuration:").toString());
+                getLog().debug(" * Context Configuration = " + an.getContextConfiguration());
+                getLog().debug(" * Include Tasks = " + an.getIncludeTasks());
+                getLog().debug(" * Exclude Tasks = " + an.getExcludeTasks());
+                final Analyser analyser = new Analyser(scanner, an.getContextConfiguration(), an.getIncludeTasks(), an.getExcludeTasks());
                 getLog().debug(MessageUtils.buffer().strong("Analyser").a(" successfully set up").toString());
 
                 getLog().debug("Retrieving Feature files...");

--- a/src/main/java/org/apache/sling/feature/maven/mojos/Scan.java
+++ b/src/main/java/org/apache/sling/feature/maven/mojos/Scan.java
@@ -16,7 +16,9 @@
  */
 package org.apache.sling.feature.maven.mojos;
 
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 public class Scan extends FeatureSelectionConfig {
@@ -24,6 +26,8 @@ public class Scan extends FeatureSelectionConfig {
     private Set<String> includeTasks = new HashSet<>();
 
     private Set<String> excludeTasks = new HashSet<>();
+
+    private Map<String, String> contextConfiguration = new HashMap<>();
 
     public void setIncludeTask(final String name) {
         this.includeTasks.add(name);
@@ -41,10 +45,14 @@ public class Scan extends FeatureSelectionConfig {
         return this.excludeTasks.isEmpty() ? null : this.excludeTasks;
     }
 
+    public Map<String, String> getContextConfiguration() {
+        return contextConfiguration;
+    }
+
     @Override
     public String toString() {
         return "Scan [filesIncludes=" + getIncludes() + ", filesExcludes=" + getExcludes() + ", includeArtifact="
                 + getArtifacts() + ", includeClassifier=" + getClassifiers() + "includeTasks=" + includeTasks
-                + ", excludeTasks=" + excludeTasks + "]";
+                + ", excludeTasks=" + excludeTasks + ", contextConfiguration=" + contextConfiguration + "]";
     }
 }


### PR DESCRIPTION
AnalyseFeaturesMojo modified in order to include the context configuration

this PR requires https://github.com/apache/sling-org-apache-sling-feature-analyser/pull/7 - the MOJO is now able to configure the context configuration so api-regions name dependencies can be arbitrary.

The PR includes Integration Test