### PR TITLE
SLING-8682 - preventing javadoc jar generation when sources dir is empty

### DIFF
--- a/src/it/apis-jar-wrapped-flattened-classes/src/main/features/main.json
+++ b/src/it/apis-jar-wrapped-flattened-classes/src/main/features/main.json
@@ -14,7 +14,7 @@
     {
       "name": "base",
       "exports": [
-        "org.apache.lucene.analysis.standard"
+        "org.apache.jackrabbit.oak.plugins.index.lucene"
       ]
     }
   ]

--- a/src/main/java/org/apache/sling/feature/maven/mojos/ApisJarMojo.java
+++ b/src/main/java/org/apache/sling/feature/maven/mojos/ApisJarMojo.java
@@ -255,9 +255,13 @@ public class ApisJarMojo extends AbstractIncludingFeatureMojo implements Artifac
             recollect(featureDir, deflatedSourcesDir, apiRegion, sourcesDir);
             inflate(feature.getId(), sourcesDir, apiRegion, SOURCES, null);
 
-            File javadocsDir = new File(regionDir, JAVADOC);
-            generateJavadoc(apiRegion, sourcesDir, javadocsDir, javadocClasspath);
-            inflate(feature.getId(), javadocsDir, apiRegion, JAVADOC, null);
+            if (sourcesDir.list().length > 0) {
+                File javadocsDir = new File(regionDir, JAVADOC);
+                generateJavadoc(apiRegion, sourcesDir, javadocsDir, javadocClasspath);
+                inflate(feature.getId(), javadocsDir, apiRegion, JAVADOC, null);
+            } else {
+                getLog().warn("Javadoc JAR will NOT be generated - sources directory was empty!");
+            }
         }
 
         getLog().debug(MessageUtils.buffer().a("APIs JARs for Feature ").debug(feature.getId().toMvnId())
@@ -875,12 +879,11 @@ public class ApisJarMojo extends AbstractIncludingFeatureMojo implements Artifac
             javadocExecutor.addArgument("-Xdoclint:none");
         }
 
-        // use the -subpackages to reduce the list of the arguments
-        if (sourcesDir.list().length > 0) {
-            javadocExecutor.addArgument("-subpackages", false);
-            javadocExecutor.addArgument(sourcesDir.list(), File.pathSeparator);
-        }
         javadocExecutor.addArgument("--allow-script-in-comments");
+
+        // use the -subpackages to reduce the list of the arguments
+        javadocExecutor.addArgument("-subpackages", false);
+        javadocExecutor.addArgument(sourcesDir.list(), File.pathSeparator);
 
         // .addArgument("-J-Xmx2048m")
         javadocExecutor.execute(javadocDir, getLog());


### PR DESCRIPTION
* preventing javadoc jar generation when sources dir is empty
* using a correct Java package existing in bundle javadoc jar in IT
