### PR TITLE
SLING-8873 - Validate the sourceId property at build time

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.feature.analyser</artifactId>
-            <version>1.2.0</version>
+            <version>1.2.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.sling</groupId>

--- a/src/main/java/org/apache/sling/feature/maven/mojos/AnalyseFeaturesMojo.java
+++ b/src/main/java/org/apache/sling/feature/maven/mojos/AnalyseFeaturesMojo.java
@@ -113,6 +113,7 @@ public class AnalyseFeaturesMojo extends AbstractIncludingFeatureMojo {
                     includedTasks = new HashSet<>();
                     includedTasks.add("bundle-packages");
                     includedTasks.add("requirements-capabilities");
+                    includedTasks.add("apis-jar");
                     if (an.getExcludeTasks() != null) {
                         includedTasks.removeAll(an.getExcludeTasks());
                         if (includedTasks.isEmpty()) {


### PR DESCRIPTION
Include the apis-jar check by default.