### PR TITLE
SLING-8906 - Include filters are too wide and can pull in unwanted resources

### DIFF
--- a/src/main/java/org/apache/sling/feature/maven/mojos/ApisJarMojo.java
+++ b/src/main/java/org/apache/sling/feature/maven/mojos/ApisJarMojo.java
@@ -401,7 +401,7 @@ public class ApisJarMojo extends AbstractIncludingFeatureMojo implements Artifac
                 // prepare filter
                 for (final ApiRegion r : regions.listRegions()) {
                     for (final ApiExport e : r.listExports()) {
-                        e.getProperties().put(PROPERTY_FILTER, packageToScannerFiler(e.getName()));
+                        e.getProperties().put(PROPERTY_FILTER, packageToScannerFiler(e.getName(), true));
                     }
                 }
 
@@ -1110,7 +1110,7 @@ public class ApisJarMojo extends AbstractIncludingFeatureMojo implements Artifac
 
         for (Clause exportedPackage : exportedPackages) {
             final String api = exportedPackage.getName();
-            exports.add(packageToScannerFiler(api));
+            exports.add(packageToScannerFiler(api, false));
         }
 
         return exports.toArray(new String[exports.size()]);
@@ -1405,8 +1405,8 @@ public class ApisJarMojo extends AbstractIncludingFeatureMojo implements Artifac
 
 
 
-    private static String packageToScannerFiler(String api) {
-        return "**/" + api.replace('.', '/') + "/*";
+    private static String packageToScannerFiler(String api, boolean strict) {
+        return (strict ? "*": "**") + '/' + api.replace('.', '/') + "/*";
     }
 
     private static String[] concatenate(String[] a, String[] b) {


### PR DESCRIPTION
Use strict filtering (one parent) when including resources from deflated bins
and sources, and relaxed filtering (multiple parents) otherwise.