### PR TITLE
Replacement PR for #41 with a clean set of changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,41 +423,68 @@ Beside the Feature Files this Mojo for now supports all the parameters
 of the current Feature Launcher (1.0.7-SNAPSHOT). For more info see the
 FeautreLaucherMojoTest.testFullLaunch() test method.
 
-## Create Feature Model Descriptor from POM (create-fm-descriptor)
+## Create Feature Model Descriptor from POM (include-artifact)
 
-A simple Maven module creates its artifact but in order to another module
-to use that in the context of a Feature Model build the module's Feature
-Module descriptor must be created during the build.
-This can be done here:
+With the **include-artifact** goal it is possible to generate a POM based
+Feature Model so that it later can be used to be incorporated into other
+Feature Models without having to reference or copy the Feature Model files.
+
+This snippet is creating a POM based Feature Model (create-test) and then
+incorporates another Feature Model (feature-test-repoinit.json) which contains
+the Repository Init instruction for that Feature Model.
+Eventually the result is installed (attach-features) into the local Maven
+repository.
+
 ```
-<!-- Generate and Install the Sling OSGi Feature Model file -->
+<!-- Generates and Installs the Sling OSGi Feature Model file -->
 <plugin>
     <groupId>org.apache.sling</groupId>
     <artifactId>slingfeature-maven-plugin</artifactId>
     <version>${slingfeature-maven-plugin.version}</version>
     <extensions>true</extensions>
     <executions>
-        <execution>
-            <id>create-fm-descriptor</id>
-            <phase>package</phase>
-            <goals>
-                <goal>include-artifact</goal>
-            </goals>
-            <configuration>
-                <classifier>jcr-packageinit</classifier>
-            </configuration>
-        </execution>
+      <execution>
+        <id>create-fm</id>
+        <phase>package</phase>
+        <goals>
+          <goal>include-artifact</goal>
+        </goals>
+        <configuration>
+          <includeArtifactClassifier>create-test</includeArtifactClassifier>
+        </configuration>
+      </execution>
+      <execution>
+        <id>aggregate</id>
+        <phase>package</phase>
+        <goals>
+          <goal>aggregate-features</goal>
+        </goals>
+        <configuration>
+          <aggregates>
+            <aggregate>
+              <!-- This must reference the classifier fro the 'create-fm' execution above -->
+              <includeClassifier>create-test</includeClassifier>
+              <filesInclude>feature-test-repoinit.json</filesInclude>
+            </aggregate>
+          </aggregates>
+        </configuration>
+      </execution>
+      <execution>
+        <id>attach</id>
+        <phase>package</phase>
+        <goals>
+          <goal>attach-features</goal>
+        </goals>
+      </execution>
     </executions>
-</plugin>
 ```
-The property **classifier** will be added only to the Feature Model
-Descriptor file name when it is installed in your local Maven repository.
-If one is provided then the user of that descriptor needs to specify it
-in the **includeArtifact**.
-The Feature Model Descriptor file name in the local Maven repository has
-this pattern:
+The **aggregate** execution above is only necessary if additional Feature Model
+Snippets are added to the final Feature Model file.
+See the **src/it/include-artifact** folders for more details.
+
+The Feature Model Descriptor file name in the local Maven repository can be found here:
 ```
-<group id>:<artifact id>-<version>=[-<classifier>].slingosgifeature
+<group id as path>/<artifact-id>/<version>/<artifact id>-<version>.slingosgifeature
 ```
 
 ## Features Diff (features-diff)

--- a/README.md
+++ b/README.md
@@ -423,6 +423,43 @@ Beside the Feature Files this Mojo for now supports all the parameters
 of the current Feature Launcher (1.0.7-SNAPSHOT). For more info see the
 FeautreLaucherMojoTest.testFullLaunch() test method.
 
+## Create Feature Model Descriptor from POM (create-fm-descriptor)
+
+A simple Maven module creates its artifact but in order to another module
+to use that in the context of a Feature Model build the module's Feature
+Module descriptor must be created during the build.
+This can be done here:
+```
+<!-- Generate and Install the Sling OSGi Feature Model file -->
+<plugin>
+    <groupId>org.apache.sling</groupId>
+    <artifactId>slingfeature-maven-plugin</artifactId>
+    <version>${slingfeature-maven-plugin.version}</version>
+    <extensions>true</extensions>
+    <executions>
+        <execution>
+            <id>create-fm-descriptor</id>
+            <phase>package</phase>
+            <goals>
+                <goal>include-artifact</goal>
+            </goals>
+            <configuration>
+                <classifier>jcr-packageinit</classifier>
+            </configuration>
+        </execution>
+    </executions>
+</plugin>
+```
+The property **classifier** will be added only to the Feature Model
+Descriptor file name when it is installed in your local Maven repository.
+If one is provided then the user of that descriptor needs to specify it
+in the **includeArtifact**.
+The Feature Model Descriptor file name in the local Maven repository has
+this pattern:
+```
+<group id>:<artifact id>-<version>=[-<classifier>].slingosgifeature
+```
+
 ## Features Diff (features-diff)
 
 This MOJO compares different versions of the same Feature Model, producing the prototype

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
         <maven.version>3.5.0</maven.version>
         <maven.scm.version>1.11.1</maven.scm.version>
         <maven.site.path>${project.artifactId}-archives/${project.artifactId}-LATEST</maven.site.path>
+        <maven-artifact-transfer.version>0.11.0</maven-artifact-transfer.version>
     </properties>
 
     <scm>
@@ -309,6 +310,11 @@
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-model-builder</artifactId>
             <version>3.6.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-artifact-transfer</artifactId>
+            <version>${maven-artifact-transfer.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/src/it/include-artifact-including-source-features-folder/invoker.properties
+++ b/src/it/include-artifact-including-source-features-folder/invoker.properties
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+invoker.goals = clean install
+invoker.debug = true

--- a/src/it/include-artifact-including-source-features-folder/pom.xml
+++ b/src/it/include-artifact-including-source-features-folder/pom.xml
@@ -79,6 +79,13 @@
               <includeArtifactClassifier>test</includeArtifactClassifier>
             </configuration>
           </execution>
+          <execution>
+            <id>attach</id>
+            <phase>package</phase>
+            <goals>
+              <goal>attach-features</goal>
+            </goals>
+          </execution>
         </executions>
       </plugin>
     </plugins>

--- a/src/it/include-artifact-including-source-features-folder/pom.xml
+++ b/src/it/include-artifact-including-source-features-folder/pom.xml
@@ -70,13 +70,28 @@
         </configuration>
         <executions>
           <execution>
-            <id>analyze</id>
+            <id>create-fm</id>
             <phase>package</phase>
             <goals>
               <goal>include-artifact</goal>
             </goals>
             <configuration>
-              <includeArtifactClassifier>test</includeArtifactClassifier>
+              <includeArtifactClassifier>create-test</includeArtifactClassifier>
+            </configuration>
+          </execution>
+          <execution>
+            <id>aggregate</id>
+            <phase>package</phase>
+            <goals>
+              <goal>aggregate-features</goal>
+            </goals>
+            <configuration>
+              <aggregates>
+                <aggregate>
+                  <includeClassifier>create-test</includeClassifier>
+                  <filesInclude>feature-test-repoinit.json</filesInclude>
+                </aggregate>
+              </aggregates>
             </configuration>
           </execution>
           <execution>

--- a/src/it/include-artifact-including-source-features-folder/pom.xml
+++ b/src/it/include-artifact-including-source-features-folder/pom.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+    agreements. See the NOTICE file distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file except in compliance with the
+    License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the
+    License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+    either express or implied. See the License for the specific language governing permissions
+    and limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.sling</groupId>
+  <artifactId>slingfeature-maven-plugin-test-include-artifact-including-source-features-folder</artifactId>
+  <packaging>jar</packaging>
+  <version>1.0.0-SNAPSHOT</version>
+
+  <name>Apache Sling Features Maven plugin test - include artifact including source features from non-default folder</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.codehaus.janino</groupId>
+      <artifactId>janino</artifactId>
+      <version>2.7.5</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.ant</groupId>
+          <artifactId>ant-nodeps</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.sling</groupId>
+      <artifactId>org.apache.sling.commons.testing</artifactId>
+      <version>2.1.2</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <!-- Remove the installation folder in the local maven repo to make sure the verification does test a newly generated installation -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-clean-plugin</artifactId>
+        <version>2.4.1</version>
+        <configuration>
+          <filesets>
+            <fileset>
+              <directory>${settings.localRepository}/org/apache/sling/${project.artifactId}</directory>
+              <includes>
+                <include>**/*</include>
+              </includes>
+              <followSymlinks>false</followSymlinks>
+            </fileset>
+          </filesets>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <extensions>true</extensions>
+        <configuration>
+          <features>src/main/fm</features>
+        </configuration>
+        <executions>
+          <execution>
+            <id>analyze</id>
+            <phase>package</phase>
+            <goals>
+              <goal>include-artifact</goal>
+            </goals>
+            <configuration>
+              <includeArtifactClassifier>test</includeArtifactClassifier>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/it/include-artifact-including-source-features-folder/src/main/fm/feature-test-repoinit.json
+++ b/src/it/include-artifact-including-source-features-folder/src/main/fm/feature-test-repoinit.json
@@ -1,0 +1,5 @@
+{
+  "repoinit:TEXT|true":[
+    "create path (rep:AuthorizableFolder) /home/users/system"
+  ]
+}

--- a/src/it/include-artifact-including-source-features-folder/verify.bsh
+++ b/src/it/include-artifact-including-source-features-folder/verify.bsh
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import java.io.*;
+import java.util.*;
+import org.codehaus.plexus.util.*;
+
+    boolean check() {
+        // Check folder and file existence
+
+        String group = "org.apache.sling";
+        String groupPath = group.replaceAll("\\.", "/");
+        String artifact = "slingfeature-maven-plugin-test-include-artifact-including-source-features-folder";
+        String version = "1.0.0-SNAPSHOT";
+        File localMavenRepositoryInstallationFolder = new File(
+            localRepositoryPath, groupPath + "/" + artifact + "/" + version
+        );
+        if(!localMavenRepositoryInstallationFolder.exists()) {
+            System.out.println("Installation Folder does not exist: " + localMavenRepositoryInstallationFolder);
+            return false;
+        }
+
+        String classifier = "test";
+        String extension = "slingosgifeature";
+        File fmDescriptorFile = new File(
+            localMavenRepositoryInstallationFolder, artifact + "-" + version + "-" + classifier + "." + extension
+        );
+        if(!fmDescriptorFile.exists()) {
+            System.out.println("FM Descriptor file does not exist: " + fmDescriptorFile);
+            return false;
+        }
+
+        // Check FM Descriptor Content
+        String fmContent = FileUtils.fileRead(fmDescriptorFile);
+        System.out.println("FM Descriptor File Content: " + fmContent);
+        String dependentGroup = "org.codehaus.janino";
+        String dependentArtifact = "janino";
+        String dependentVersion = "2.7.5";
+        String[] values = {
+            "\"id\":\"" + group + ":" + artifact + ":slingosgifeature:" + classifier + ":" + version + "\"",
+            "\"bundles\":[",
+            group + ":" + artifact + ":" + version + "\"",
+            "\"repoinit:TEXT|true\":[",
+            "\"create path (rep:AuthorizableFolder) /home/users/system\""
+        };
+        for (String value : values) {
+            if (fmContent.indexOf(value) < 0) {
+                System.out.println("Did not find line: " + value + " -> FAILED!");
+                return false;
+            }
+        }
+
+        return true;
+    }
+    try {
+        return check();
+    }
+    catch(Throwable t) {
+        t.printStackTrace();
+        return false;
+    }
+    return true;

--- a/src/it/include-artifact-including-source-features-folder/verify.bsh
+++ b/src/it/include-artifact-including-source-features-folder/verify.bsh
@@ -36,7 +36,7 @@ import org.codehaus.plexus.util.*;
         String classifier = "test";
         String extension = "slingosgifeature";
         File fmDescriptorFile = new File(
-            localMavenRepositoryInstallationFolder, artifact + "-" + version + "-" + classifier + "." + extension
+            localMavenRepositoryInstallationFolder, artifact + "-" + version + "." + extension
         );
         if(!fmDescriptorFile.exists()) {
             System.out.println("FM Descriptor file does not exist: " + fmDescriptorFile);
@@ -50,7 +50,7 @@ import org.codehaus.plexus.util.*;
         String dependentArtifact = "janino";
         String dependentVersion = "2.7.5";
         String[] values = {
-            "\"id\":\"" + group + ":" + artifact + ":slingosgifeature:" + classifier + ":" + version + "\"",
+            "\"id\":\"" + group + ":" + artifact + ":slingosgifeature:" + version + "\"",
             "\"bundles\":[",
             group + ":" + artifact + ":" + version + "\"",
             "\"repoinit:TEXT|true\":[",

--- a/src/it/include-artifact-including-source-features/invoker.properties
+++ b/src/it/include-artifact-including-source-features/invoker.properties
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+invoker.goals = clean install
+invoker.debug = true

--- a/src/it/include-artifact-including-source-features/pom.xml
+++ b/src/it/include-artifact-including-source-features/pom.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+    agreements. See the NOTICE file distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file except in compliance with the
+    License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the
+    License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+    either express or implied. See the License for the specific language governing permissions
+    and limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.sling</groupId>
+  <artifactId>slingfeature-maven-plugin-test-include-artifact-including-source-features</artifactId>
+  <packaging>jar</packaging>
+  <version>1.0.0-SNAPSHOT</version>
+
+  <name>Apache Sling Features Maven plugin test - include artifact including source features</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.codehaus.janino</groupId>
+      <artifactId>janino</artifactId>
+      <version>2.7.5</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.ant</groupId>
+          <artifactId>ant-nodeps</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.sling</groupId>
+      <artifactId>org.apache.sling.commons.testing</artifactId>
+      <version>2.1.2</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <!-- Remove the installation folder in the local maven repo to make sure the verification does test a newly generated installation -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-clean-plugin</artifactId>
+        <version>2.4.1</version>
+        <configuration>
+          <filesets>
+            <fileset>
+              <directory>${settings.localRepository}/org/apache/sling/${project.artifactId}</directory>
+              <includes>
+                <include>**/*</include>
+              </includes>
+              <followSymlinks>false</followSymlinks>
+            </fileset>
+          </filesets>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <extensions>true</extensions>
+        <executions>
+          <execution>
+            <id>analyze</id>
+            <phase>package</phase>
+            <goals>
+              <goal>include-artifact</goal>
+            </goals>
+            <configuration>
+              <includeArtifactClassifier>test</includeArtifactClassifier>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/it/include-artifact-including-source-features/pom.xml
+++ b/src/it/include-artifact-including-source-features/pom.xml
@@ -76,6 +76,13 @@
               <includeArtifactClassifier>test</includeArtifactClassifier>
             </configuration>
           </execution>
+          <execution>
+            <id>attach</id>
+            <phase>package</phase>
+            <goals>
+              <goal>attach-features</goal>
+            </goals>
+          </execution>
         </executions>
       </plugin>
     </plugins>

--- a/src/it/include-artifact-including-source-features/pom.xml
+++ b/src/it/include-artifact-including-source-features/pom.xml
@@ -73,7 +73,22 @@
               <goal>include-artifact</goal>
             </goals>
             <configuration>
-              <includeArtifactClassifier>test</includeArtifactClassifier>
+              <includeArtifactClassifier>create-test</includeArtifactClassifier>
+            </configuration>
+          </execution>
+          <execution>
+            <id>aggregate</id>
+            <phase>package</phase>
+            <goals>
+              <goal>aggregate-features</goal>
+            </goals>
+            <configuration>
+              <aggregates>
+                <aggregate>
+                  <includeClassifier>create-test</includeClassifier>
+                  <filesInclude>feature-test-repoinit.json</filesInclude>
+                </aggregate>
+              </aggregates>
             </configuration>
           </execution>
           <execution>

--- a/src/it/include-artifact-including-source-features/src/main/features/feature-test-repoinit.json
+++ b/src/it/include-artifact-including-source-features/src/main/features/feature-test-repoinit.json
@@ -1,0 +1,5 @@
+{
+  "repoinit:TEXT|true":[
+    "create path (rep:AuthorizableFolder) /home/users/system"
+  ]
+}

--- a/src/it/include-artifact-including-source-features/verify.bsh
+++ b/src/it/include-artifact-including-source-features/verify.bsh
@@ -36,7 +36,7 @@ import org.codehaus.plexus.util.*;
         String classifier = "test";
         String extension = "slingosgifeature";
         File fmDescriptorFile = new File(
-            localMavenRepositoryInstallationFolder, artifact + "-" + version + "-" + classifier + "." + extension
+            localMavenRepositoryInstallationFolder, artifact + "-" + version + "." + extension
         );
         if(!fmDescriptorFile.exists()) {
             System.out.println("FM Descriptor file does not exist: " + fmDescriptorFile);
@@ -44,14 +44,13 @@ import org.codehaus.plexus.util.*;
         }
 
         // Check FM Descriptor Content
-        System.out.println("FM Descriptor File Path: " + fmDescriptorFile);
         String fmContent = FileUtils.fileRead(fmDescriptorFile);
         System.out.println("FM Descriptor File Content: " + fmContent);
         String dependentGroup = "org.codehaus.janino";
         String dependentArtifact = "janino";
         String dependentVersion = "2.7.5";
         String[] values = {
-            "\"id\":\"" + group + ":" + artifact + ":slingosgifeature:" + classifier + ":" + version + "\"",
+            "\"id\":\"" + group + ":" + artifact + ":slingosgifeature:" + version + "\"",
             "\"bundles\":[",
             group + ":" + artifact + ":" + version + "\"",
             "\"repoinit:TEXT|true\":[",

--- a/src/it/include-artifact-including-source-features/verify.bsh
+++ b/src/it/include-artifact-including-source-features/verify.bsh
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import java.io.*;
+import java.util.*;
+import org.codehaus.plexus.util.*;
+
+    boolean check() {
+        // Check folder and file existence
+
+        String group = "org.apache.sling";
+        String groupPath = group.replaceAll("\\.", "/");
+        String artifact = "slingfeature-maven-plugin-test-include-artifact-including-source-features";
+        String version = "1.0.0-SNAPSHOT";
+        File localMavenRepositoryInstallationFolder = new File(
+            localRepositoryPath, groupPath + "/" + artifact + "/" + version
+        );
+        if(!localMavenRepositoryInstallationFolder.exists()) {
+            System.out.println("Installation Folder does not exist: " + localMavenRepositoryInstallationFolder);
+            return false;
+        }
+
+        String classifier = "test";
+        String extension = "slingosgifeature";
+        File fmDescriptorFile = new File(
+            localMavenRepositoryInstallationFolder, artifact + "-" + version + "-" + classifier + "." + extension
+        );
+        if(!fmDescriptorFile.exists()) {
+            System.out.println("FM Descriptor file does not exist: " + fmDescriptorFile);
+            return false;
+        }
+
+        // Check FM Descriptor Content
+        System.out.println("FM Descriptor File Path: " + fmDescriptorFile);
+        String fmContent = FileUtils.fileRead(fmDescriptorFile);
+        System.out.println("FM Descriptor File Content: " + fmContent);
+        String dependentGroup = "org.codehaus.janino";
+        String dependentArtifact = "janino";
+        String dependentVersion = "2.7.5";
+        String[] values = {
+            "\"id\":\"" + group + ":" + artifact + ":slingosgifeature:" + classifier + ":" + version + "\"",
+            "\"bundles\":[",
+            group + ":" + artifact + ":" + version + "\"",
+            "\"repoinit:TEXT|true\":[",
+            "\"create path (rep:AuthorizableFolder) /home/users/system\""
+        };
+        for (String value : values) {
+            if (fmContent.indexOf(value) < 0) {
+                System.out.println("Did not find line: " + value + " -> FAILED!");
+                return false;
+            }
+        }
+
+        return true;
+    }
+    try {
+        return check();
+    }
+    catch(Throwable t) {
+        t.printStackTrace();
+        return false;
+    }
+    return true;

--- a/src/it/include-artifact-no-classifier/invoker.properties
+++ b/src/it/include-artifact-no-classifier/invoker.properties
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+invoker.goals = clean install
+invoker.debug = true

--- a/src/it/include-artifact-no-classifier/pom.xml
+++ b/src/it/include-artifact-no-classifier/pom.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+    agreements. See the NOTICE file distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file except in compliance with the
+    License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the
+    License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+    either express or implied. See the License for the specific language governing permissions
+    and limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.sling</groupId>
+  <artifactId>slingfeature-maven-plugin-test-include-artifact-no-classifier</artifactId>
+  <packaging>jar</packaging>
+  <version>1.0.0-SNAPSHOT</version>
+
+  <name>Apache Sling Features Maven plugin test - include artifact with no classifier</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.codehaus.janino</groupId>
+      <artifactId>janino</artifactId>
+      <version>2.7.5</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.ant</groupId>
+          <artifactId>ant-nodeps</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.sling</groupId>
+      <artifactId>org.apache.sling.commons.testing</artifactId>
+      <version>2.1.2</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <!-- Remove the installation folder in the local maven repo to make sure the verification does test a newly generated installation -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-clean-plugin</artifactId>
+        <version>2.4.1</version>
+        <configuration>
+          <filesets>
+            <fileset>
+              <directory>${settings.localRepository}/org/apache/sling/${project.artifactId}</directory>
+              <includes>
+                <include>**/*</include>
+              </includes>
+              <followSymlinks>false</followSymlinks>
+            </fileset>
+          </filesets>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <extensions>true</extensions>
+        <executions>
+          <execution>
+            <id>analyze</id>
+            <phase>package</phase>
+            <goals>
+              <goal>include-artifact</goal>
+            </goals>
+            <configuration>
+              <includeDependenciesWithScope>compile</includeDependenciesWithScope>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/it/include-artifact-no-classifier/pom.xml
+++ b/src/it/include-artifact-no-classifier/pom.xml
@@ -76,6 +76,13 @@
               <includeDependenciesWithScope>compile</includeDependenciesWithScope>
             </configuration>
           </execution>
+          <execution>
+            <id>attach</id>
+            <phase>package</phase>
+            <goals>
+              <goal>attach-features</goal>
+            </goals>
+          </execution>
         </executions>
       </plugin>
     </plugins>

--- a/src/it/include-artifact-no-classifier/verify.bsh
+++ b/src/it/include-artifact-no-classifier/verify.bsh
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import java.io.*;
+import java.util.*;
+import org.codehaus.plexus.util.*;
+
+    boolean check() {
+        // Check folder and file existence
+
+        String group = "org.apache.sling";
+        String groupPath = group.replaceAll("\\.", "/");
+        String artifact = "slingfeature-maven-plugin-test-include-artifact-no-classifier";
+        String version = "1.0.0-SNAPSHOT";
+        File localMavenRepositoryInstallationFolder = new File(
+            localRepositoryPath, groupPath + "/" + artifact + "/" + version
+        );
+        if(!localMavenRepositoryInstallationFolder.exists()) {
+            System.out.println("Installation Folder does not exist: " + localMavenRepositoryInstallationFolder);
+            return false;
+        }
+
+        String extension = "slingosgifeature";
+        File fmDescriptorFile = new File(
+            localMavenRepositoryInstallationFolder, artifact + "-" + version + "." + extension
+        );
+        if(!fmDescriptorFile.exists()) {
+            System.out.println("FM Descriptor file does not exist: " + fmDescriptorFile);
+            return false;
+        }
+
+        // Check FM Descriptor Content
+        String fmContent = FileUtils.fileRead(fmDescriptorFile);
+        System.out.println("FM Descriptor File Content: " + fmContent);
+        String dependentGroup = "org.codehaus.janino";
+        String dependentArtifact = "janino";
+        String dependentVersion = "2.7.5";
+        String[] values = {
+            "\"id\":\"" + group + ":" + artifact + ":slingosgifeature:" + version + "\"",
+            "\"bundles\":[",
+            group + ":" + artifact + ":" + version + "\"",
+            dependentGroup + ":" + dependentArtifact + ":" + dependentVersion + "\"",
+        };
+        for (String value : values) {
+            if (fmContent.indexOf(value) < 0) {
+                System.out.println("Did not find line: " + value + " -> FAILED!");
+                return false;
+            }
+        }
+
+        return true;
+    }
+    try {
+        return check();
+    }
+    catch(Throwable t) {
+        t.printStackTrace();
+        return false;
+    }
+    return true;

--- a/src/it/include-artifact-simple/invoker.properties
+++ b/src/it/include-artifact-simple/invoker.properties
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+invoker.goals = clean install
+invoker.debug = true

--- a/src/it/include-artifact-simple/pom.xml
+++ b/src/it/include-artifact-simple/pom.xml
@@ -77,6 +77,13 @@
               <includeDependenciesWithScope>compile</includeDependenciesWithScope>
             </configuration>
           </execution>
+          <execution>
+            <id>attach</id>
+            <phase>package</phase>
+            <goals>
+              <goal>attach-features</goal>
+            </goals>
+          </execution>
         </executions>
       </plugin>
     </plugins>

--- a/src/it/include-artifact-simple/pom.xml
+++ b/src/it/include-artifact-simple/pom.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+    agreements. See the NOTICE file distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file except in compliance with the
+    License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the
+    License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+    either express or implied. See the License for the specific language governing permissions
+    and limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.sling</groupId>
+  <artifactId>slingfeature-maven-plugin-test-include-artifact-simple</artifactId>
+  <packaging>jar</packaging>
+  <version>1.0.0-SNAPSHOT</version>
+
+  <name>Apache Sling Features Maven plugin test - include artifact simple</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.codehaus.janino</groupId>
+      <artifactId>janino</artifactId>
+      <version>2.7.5</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.ant</groupId>
+          <artifactId>ant-nodeps</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.sling</groupId>
+      <artifactId>org.apache.sling.commons.testing</artifactId>
+      <version>2.1.2</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <!-- Remove the installation folder in the local maven repo to make sure the verification does test a newly generated installation -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-clean-plugin</artifactId>
+        <version>2.4.1</version>
+        <configuration>
+          <filesets>
+            <fileset>
+              <directory>${settings.localRepository}/org/apache/sling/${project.artifactId}</directory>
+              <includes>
+                <include>**/*</include>
+              </includes>
+              <followSymlinks>false</followSymlinks>
+            </fileset>
+          </filesets>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <extensions>true</extensions>
+        <executions>
+          <execution>
+            <id>analyze</id>
+            <phase>package</phase>
+            <goals>
+              <goal>include-artifact</goal>
+            </goals>
+            <configuration>
+              <includeArtifactClassifier>test</includeArtifactClassifier>
+              <includeDependenciesWithScope>compile</includeDependenciesWithScope>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/it/include-artifact-simple/verify.bsh
+++ b/src/it/include-artifact-simple/verify.bsh
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import java.io.*;
+import java.util.*;
+import org.codehaus.plexus.util.*;
+
+    boolean check() {
+        // Check folder and file existence
+
+        String group = "org.apache.sling";
+        String groupPath = group.replaceAll("\\.", "/");
+        String artifact = "slingfeature-maven-plugin-test-include-artifact-simple";
+        String version = "1.0.0-SNAPSHOT";
+        File localMavenRepositoryInstallationFolder = new File(
+            localRepositoryPath, groupPath + "/" + artifact + "/" + version
+        );
+        if(!localMavenRepositoryInstallationFolder.exists()) {
+            System.out.println("Installation Folder does not exist: " + localMavenRepositoryInstallationFolder);
+            return false;
+        }
+
+        String classifier = "test";
+        String extension = "slingosgifeature";
+        File fmDescriptorFile = new File(
+            localMavenRepositoryInstallationFolder, artifact + "-" + version + "-" + classifier + "." + extension
+        );
+        if(!fmDescriptorFile.exists()) {
+            System.out.println("FM Descriptor file does not exist: " + fmDescriptorFile);
+            return false;
+        }
+
+        // Check FM Descriptor Content
+        String fmContent = FileUtils.fileRead(fmDescriptorFile);
+        System.out.println("FM Descriptor File Content: " + fmContent);
+        String dependentGroup = "org.codehaus.janino";
+        String dependentArtifact = "janino";
+        String dependentVersion = "2.7.5";
+        String[] values = {
+            "\"id\":\"" + group + ":" + artifact + ":slingosgifeature:" + classifier + ":" + version + "\"",
+            "\"bundles\":[",
+            group + ":" + artifact + ":" + version + "\"",
+            dependentGroup + ":" + dependentArtifact + ":" + dependentVersion + "\"",
+        };
+        for (String value : values) {
+            if (fmContent.indexOf(value) < 0) {
+                System.out.println("Did not find line: " + value + " -> FAILED!");
+                return false;
+            }
+        }
+
+        return true;
+    }
+    try {
+        return check();
+    }
+    catch(Throwable t) {
+        t.printStackTrace();
+        return false;
+    }
+    return true;

--- a/src/it/include-artifact-start-order/invoker.properties
+++ b/src/it/include-artifact-start-order/invoker.properties
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+invoker.goals = clean install
+invoker.debug = true

--- a/src/it/include-artifact-start-order/pom.xml
+++ b/src/it/include-artifact-start-order/pom.xml
@@ -78,6 +78,13 @@
               <bundlesStartOrder>20</bundlesStartOrder>
             </configuration>
           </execution>
+          <execution>
+            <id>attach</id>
+            <phase>package</phase>
+            <goals>
+              <goal>attach-features</goal>
+            </goals>
+          </execution>
         </executions>
       </plugin>
     </plugins>

--- a/src/it/include-artifact-start-order/pom.xml
+++ b/src/it/include-artifact-start-order/pom.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+    agreements. See the NOTICE file distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file except in compliance with the
+    License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the
+    License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+    either express or implied. See the License for the specific language governing permissions
+    and limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.sling</groupId>
+  <artifactId>slingfeature-maven-plugin-test-include-artifact-start-order</artifactId>
+  <packaging>jar</packaging>
+  <version>1.0.0-SNAPSHOT</version>
+
+  <name>Apache Sling Features Maven plugin test - include artifact with start order</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.codehaus.janino</groupId>
+      <artifactId>janino</artifactId>
+      <version>2.7.5</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.ant</groupId>
+          <artifactId>ant-nodeps</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.sling</groupId>
+      <artifactId>org.apache.sling.commons.testing</artifactId>
+      <version>2.1.2</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <!-- Remove the installation folder in the local maven repo to make sure the verification does test a newly generated installation -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-clean-plugin</artifactId>
+        <version>2.4.1</version>
+        <configuration>
+          <filesets>
+            <fileset>
+              <directory>${settings.localRepository}/org/apache/sling/${project.artifactId}</directory>
+              <includes>
+                <include>**/*</include>
+              </includes>
+              <followSymlinks>false</followSymlinks>
+            </fileset>
+          </filesets>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <extensions>true</extensions>
+        <executions>
+          <execution>
+            <id>analyze</id>
+            <phase>package</phase>
+            <goals>
+              <goal>include-artifact</goal>
+            </goals>
+            <configuration>
+              <includeArtifactClassifier>test</includeArtifactClassifier>
+              <includeDependenciesWithScope>compile</includeDependenciesWithScope>
+              <bundlesStartOrder>20</bundlesStartOrder>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/it/include-artifact-start-order/verify.bsh
+++ b/src/it/include-artifact-start-order/verify.bsh
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import java.io.*;
+import java.util.*;
+import org.codehaus.plexus.util.*;
+
+    boolean check() {
+        // Check folder and file existence
+
+        String group = "org.apache.sling";
+        String groupPath = group.replaceAll("\\.", "/");
+        String artifact = "slingfeature-maven-plugin-test-include-artifact-start-order";
+        String version = "1.0.0-SNAPSHOT";
+        File localMavenRepositoryInstallationFolder = new File(
+            localRepositoryPath, groupPath + "/" + artifact + "/" + version
+        );
+        if(!localMavenRepositoryInstallationFolder.exists()) {
+            System.out.println("Installation Folder does not exist: " + localMavenRepositoryInstallationFolder);
+            return false;
+        }
+
+        String classifier = "test";
+        String extension = "slingosgifeature";
+        File fmDescriptorFile = new File(
+            localMavenRepositoryInstallationFolder, artifact + "-" + version + "-" + classifier + "." + extension
+        );
+        if(!fmDescriptorFile.exists()) {
+            System.out.println("FM Descriptor file does not exist: " + fmDescriptorFile);
+            return false;
+        }
+
+        // Check FM Descriptor Content
+        String fmContent = FileUtils.fileRead(fmDescriptorFile);
+        System.out.println("FM Descriptor File Content: " + fmContent);
+        String dependentGroup = "org.codehaus.janino";
+        String dependentArtifact = "janino";
+        String dependentVersion = "2.7.5";
+        String[] values = {
+            "\"id\":\"" + group + ":" + artifact + ":slingosgifeature:" + classifier + ":" + version + "\"",
+            "\"bundles\":[",
+            group + ":" + artifact + ":" + version + "\"",
+            "\"id\":\"" + dependentGroup + ":" + dependentArtifact + ":" + dependentVersion + "\"",
+        };
+        for (String value : values) {
+            if (fmContent.indexOf(value) < 0) {
+                System.out.println("Did not find line: " + value + " -> FAILED!");
+                return false;
+            }
+        }
+
+        return true;
+    }
+    try {
+        return check();
+    }
+    catch(Throwable t) {
+        t.printStackTrace();
+        return false;
+    }
+    return true;

--- a/src/main/java/org/apache/sling/feature/maven/mojos/IncludeArtifactMojo.java
+++ b/src/main/java/org/apache/sling/feature/maven/mojos/IncludeArtifactMojo.java
@@ -16,8 +16,6 @@
  */
 package org.apache.sling.feature.maven.mojos;
 
-import org.apache.maven.artifact.DefaultArtifact;
-import org.apache.maven.artifact.handler.DefaultArtifactHandler;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -30,12 +28,9 @@ import org.apache.maven.shared.transfer.artifact.install.ArtifactInstaller;
 import org.apache.sling.feature.Artifact;
 import org.apache.sling.feature.ArtifactId;
 import org.apache.sling.feature.Artifacts;
-import org.apache.sling.feature.Bundles;
-import org.apache.sling.feature.Configurations;
 import org.apache.sling.feature.Extension;
 import org.apache.sling.feature.ExtensionState;
 import org.apache.sling.feature.ExtensionType;
-import org.apache.sling.feature.Extensions;
 import org.apache.sling.feature.Feature;
 import org.apache.sling.feature.io.json.FeatureJSONWriter;
 import org.apache.sling.feature.maven.FeatureConstants;
@@ -45,9 +40,6 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Writer;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -158,7 +150,6 @@ public class IncludeArtifactMojo extends AbstractIncludingFeatureMojo {
         if(file != null) {
             featureSelectionConfig.setFilesExclude("**/" + file.getName());
         }
-        final Map<String, Feature> selection = this.getSelectedFeatures(featureSelectionConfig);
 
         if (file != null) {
             try ( final Writer writer = new FileWriter(file)) {

--- a/src/main/java/org/apache/sling/feature/maven/mojos/IncludeArtifactMojo.java
+++ b/src/main/java/org/apache/sling/feature/maven/mojos/IncludeArtifactMojo.java
@@ -160,9 +160,6 @@ public class IncludeArtifactMojo extends AbstractIncludingFeatureMojo {
         }
         final Map<String, Feature> selection = this.getSelectedFeatures(featureSelectionConfig);
 
-        includeFeatures(selection, found);
-
-        // Write the Feature into its file and install it
         if (file != null) {
             try ( final Writer writer = new FileWriter(file)) {
                 FeatureJSONWriter.write(writer, found);
@@ -211,29 +208,5 @@ public class IncludeArtifactMojo extends AbstractIncludingFeatureMojo {
                 }
             }
         }
-    }
-
-    private void includeFeatures(Map<String, Feature> selection, Feature feature) {
-        getLog().debug("Including Features found: " + selection);
-        for(Feature childFeature: selection.values()) {
-            getLog().debug("Including Feature found: " + childFeature);
-            Extensions extensions = childFeature.getExtensions();
-            if(extensions != null && !extensions.isEmpty()) {
-                feature.getExtensions().addAll(extensions);
-            }
-            Map<String,String> frameworkProperties = childFeature.getFrameworkProperties();
-            if(frameworkProperties != null && !frameworkProperties.isEmpty()) {
-                feature.getFrameworkProperties().putAll(frameworkProperties);
-            }
-            Bundles bundles = childFeature.getBundles();
-            if(bundles != null && !bundles.isEmpty()) {
-                feature.getBundles().addAll(bundles);
-            }
-            Configurations configurations = childFeature.getConfigurations();
-            if(configurations != null && !configurations.isEmpty()) {
-                feature.getConfigurations().addAll(configurations);
-            }
-        }
-
     }
 }

--- a/src/main/java/org/apache/sling/feature/maven/mojos/IncludeArtifactMojo.java
+++ b/src/main/java/org/apache/sling/feature/maven/mojos/IncludeArtifactMojo.java
@@ -136,20 +136,11 @@ public class IncludeArtifactMojo extends AbstractIncludingFeatureMojo {
             ProjectHelper.getFeatures(this.project).put(key, found);
             ProjectHelper.getAssembledFeatures(this.project).put(key, found);
         }
-        getLog().debug("Found Feature: " + found + ", artifact: " + art);
         includeArtifact(found, includeArtifactExtension, art);
-        getLog().debug("Feature Key: " + key + ", feature from key: " + ProjectHelper.getAssembledFeatures(this.project).get(key));
         includeArtifact(ProjectHelper.getAssembledFeatures(this.project).get(key), includeArtifactExtension,
                 art.copy(art.getId()));
 
         addDependencies(found);
-
-        // Obtain any features from Source folder and add any Extensions to the target feature
-        final FeatureSelectionConfig featureSelectionConfig = new FeatureSelectionConfig();
-        featureSelectionConfig.setFilesInclude("**/*.json" );
-        if(file != null) {
-            featureSelectionConfig.setFilesExclude("**/" + file.getName());
-        }
 
         if (file != null) {
             try ( final Writer writer = new FileWriter(file)) {
@@ -165,10 +156,8 @@ public class IncludeArtifactMojo extends AbstractIncludingFeatureMojo {
         Artifacts container = f.getBundles();
         if (extensionName != null) {
             Extension ext = f.getExtensions().getByName(extensionName);
-            getLog().debug("Extension: " + extensionName + ", found extension: " + ext);
             if (ext == null) {
                 ext = new Extension(ExtensionType.ARTIFACTS, extensionName, ExtensionState.REQUIRED);
-                getLog().debug("New Extension: " + ext);
                 f.getExtensions().add(ext);
             }
             if (ext.getType() != ExtensionType.ARTIFACTS) {
@@ -184,10 +173,8 @@ public class IncludeArtifactMojo extends AbstractIncludingFeatureMojo {
         // Add Dependencies if configured so
         for(String includeDependencyScope: includeDependenciesWithScope) {
             List<Dependency> dependencies = project.getDependencies();
-            getLog().info("Project Dependencies: " + dependencies);
             for(Dependency dependency: dependencies) {
                 if(includeDependencyScope.equals(dependency.getScope())) {
-                    getLog().info("Include Artifact: " + dependencies);
                     ArtifactId id = new ArtifactId(
                         dependency.getGroupId(), dependency.getArtifactId(), dependency.getVersion(), dependency.getClassifier(), dependency.getType()
                     );


### PR DESCRIPTION
This is a redo of the PR #41 with a clean set of changes.

Any project that wants to assemble a Project FM by including existing FMs needs a way to install the source FMs from a POM into the local Maven repo first.