### PR TITLE
SLING-9461 Access Feature Model Aggregates as Files during Maven Build, even if they're not attached

### DIFF
--- a/src/main/java/org/apache/sling/feature/maven/mojos/AggregateFeaturesMojo.java
+++ b/src/main/java/org/apache/sling/feature/maven/mojos/AggregateFeaturesMojo.java
@@ -147,10 +147,8 @@ public class AggregateFeaturesMojo extends AbstractIncludingFeatureMojo {
             if (aggregate.vendor != null) {
                 result.setVendor(aggregate.vendor);
             }
-            if (aggregate.attach) {
-                ProjectHelper.createTmpFeatureFile(project, result);
-            }
 
+            ProjectHelper.createTmpFeatureFile(project, result);
             ProjectHelper.setFeatureInfo(project, result);
 
             // Add feature to map of features


### PR DESCRIPTION
The writeToDisk boolean attribute can be set to true on aggregates that are not
attached to have them written to disk during the build process.