### PR TITLE
Fixes bug: jarStartOrder can only be set for FMs in the source folder.

### DIFF
--- a/src/main/java/org/apache/sling/feature/maven/mojos/AbstractFeatureMojo.java
+++ b/src/main/java/org/apache/sling/feature/maven/mojos/AbstractFeatureMojo.java
@@ -163,7 +163,7 @@ public abstract class AbstractFeatureMojo extends AbstractMojo {
      * The start level for the attached jar/bundle.
      */
     @Parameter(name=FeatureProjectConfig.CFG_JAR_START_ORDER)
-    protected String jarStartOrder;
+    protected int jarStartOrder;
 
     /**
      * Enable the replacement of variables when reading a feature model. The supported

--- a/src/main/java/org/apache/sling/feature/maven/mojos/AbstractFeatureMojo.java
+++ b/src/main/java/org/apache/sling/feature/maven/mojos/AbstractFeatureMojo.java
@@ -163,7 +163,7 @@ public abstract class AbstractFeatureMojo extends AbstractMojo {
      * The start level for the attached jar/bundle.
      */
     @Parameter(name=FeatureProjectConfig.CFG_JAR_START_ORDER)
-    private int jarStartOrder;
+    protected String jarStartOrder;
 
     /**
      * Enable the replacement of variables when reading a feature model. The supported

--- a/src/main/java/org/apache/sling/feature/maven/mojos/IncludeArtifactMojo.java
+++ b/src/main/java/org/apache/sling/feature/maven/mojos/IncludeArtifactMojo.java
@@ -160,8 +160,8 @@ public class IncludeArtifactMojo extends AbstractIncludingFeatureMojo {
         final Artifact art = new Artifact(new ArtifactId(this.project.getGroupId(), this.project.getArtifactId(),
                 this.project.getVersion(), includeClassifier, includeType != null ? includeType : this.project.getArtifact().getType()));
 
-        if(jarStartOrder != null) {
-            art.setStartOrder(Integer.parseInt(jarStartOrder));
+        if(jarStartOrder > 0) {
+            art.setStartOrder(jarStartOrder);
         }
 
         if (metadata != null && metadata.size() > 0) {

--- a/src/main/java/org/apache/sling/feature/maven/mojos/IncludeArtifactMojo.java
+++ b/src/main/java/org/apache/sling/feature/maven/mojos/IncludeArtifactMojo.java
@@ -159,6 +159,11 @@ public class IncludeArtifactMojo extends AbstractIncludingFeatureMojo {
 
         final Artifact art = new Artifact(new ArtifactId(this.project.getGroupId(), this.project.getArtifactId(),
                 this.project.getVersion(), includeClassifier, includeType != null ? includeType : this.project.getArtifact().getType()));
+
+        if(jarStartOrder != null) {
+            art.setStartOrder(Integer.parseInt(jarStartOrder));
+        }
+
         if (metadata != null && metadata.size() > 0) {
             art.getMetadata().putAll(metadata);
         }


### PR DESCRIPTION
During include-artifact mojo execution the start level for the attached jar/bundle can be set through jarStartOrder.
This was only working for FM files inside the source folder. For created FMs the jar/bundle would not receive the jarStartOrder.

The jarStartOrder param was changed from int to String because otherwise the not null check wouldnt be possible. Without the not null check the start order would be added always.