### PR TITLE
SLING-10060 Substitutions for the "replacePropertyVariables" values should prefer the system property value

### DIFF
--- a/src/main/java/org/apache/sling/feature/maven/Substitution.java
+++ b/src/main/java/org/apache/sling/feature/maven/Substitution.java
@@ -67,8 +67,15 @@ public class Substitution {
             if ( additionalProperties != null ) {
                 for(String p : additionalProperties) {
                     p = p.trim();
-                    if ( project.getProperties().containsKey(p)) {
-                        props.setProperty(p, project.getProperties().getProperty(p));
+                    // check for a system property that overwrites the project property
+                    String value = System.getProperty(p);
+                    if (value == null && project.getProperties().containsKey(p)) {
+                        // no system property, so try the project property
+                        value = project.getProperties().getProperty(p);
+                    }
+                    if (value != null) {
+                        // found a value
+                        props.setProperty(p, value);
                     }
                 }
             }

--- a/src/test/java/org/apache/sling/feature/maven/SubstitutionTest.java
+++ b/src/test/java/org/apache/sling/feature/maven/SubstitutionTest.java
@@ -52,6 +52,31 @@ public class SubstitutionTest {
         }
     }
 
+    /**
+     * SLING-10060 Verify that the additional properties prefer the system property 
+     * value (if available) over the project property value
+     */
+    @Test
+    public void testReplaceAdditionalPropertiesMavenVarsWithSystemProperties() {
+        Properties storedProps = new Properties();
+        storedProps.putAll(System.getProperties());
+
+        try {
+            MavenProject proj = new MavenProject();
+            Properties p = proj.getProperties();
+            p.put("test", "foo");
+            p.put("test2", "foo2");
+
+            // set system property to override the project property
+            System.setProperty("test", "bar");
+
+            assertEquals("hellobargoodbyefoo2", Substitution.replaceMavenVars(proj, false, false, new String[] {"test", "test2"}, "hello${test}goodbye${test2}"));
+        } finally {
+            // Restore the system properties
+            System.setProperties(storedProps);
+        }
+    }
+
     @Test
     public void testOSGiVersion() {
     	assertEquals("1.2.3", Substitution.getOSGiVersion("1.2.3"));


### PR DESCRIPTION
Substitutions for the "replacePropertyVariables" values should prefer the system property value (if available) over the project property value.  

For example, the use case of a parameterized jenkins job where the users choice should be passed along to maven and used to configure/prepare the environment to run a set of tests against.