### PR TITLE
SLING-10069 The generated features target dir is created in the wrong place

### DIFF
--- a/src/main/java/org/apache/sling/feature/maven/mojos/AbstractFeatureMojo.java
+++ b/src/main/java/org/apache/sling/feature/maven/mojos/AbstractFeatureMojo.java
@@ -21,6 +21,8 @@ import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
 import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -241,12 +243,21 @@ public abstract class AbstractFeatureMojo extends AbstractMojo {
     private void handleGeneratedFeatures() throws MojoExecutionException {
         final File dir;
         if (this.generatedFeatures == null) {
-            final File targetDir = new File(this.project.getBasedir(), this.project.getBuild().getDirectory());
+            Path targetPath = null;
+            File basedir = this.project.getBasedir();
+            if (basedir == null) {
+                // no basedir? use the build directory instead.
+                targetPath = Paths.get(this.project.getBuild().getDirectory());
+            } else {
+                // resolve build directory relative to the basedir path
+                targetPath = basedir.toPath().resolve(this.project.getBuild().getDirectory());
+            }
+            final File targetDir = targetPath == null ? null : targetPath.toFile();
             final File genDir = new File(targetDir, "generated-features");
             if (genDir.exists()) {
                 dir = genDir;
             } else {
-                if(genDir.mkdirs()) {
+                if (genDir.mkdirs()) {
                     dir = genDir;
                 } else {
                     dir = null;
@@ -257,7 +268,7 @@ public abstract class AbstractFeatureMojo extends AbstractMojo {
         }
         if (dir != null) {
             if (!dir.exists()) {
-                if(!dir.mkdirs()) {
+                if (!dir.mkdirs()) {
                     throw new MojoExecutionException("Directory does not exists: " + dir);
                 }
             }


### PR DESCRIPTION
After switching to the 1.4.22 release version of the plugin, I noticed that the change for SLING-10035 appears to be creating a set of empty folders in the wrong place in my linux environment.

Using a debugger, I see that the targetDir File object is constructed at AbstractFeatureMojo line 244 with the "child" second argument already resolved to be an absolute path.  This appears to append the absolute child path to the parent path rather than checking if "child" is relative or absolute to resolve it.

Expect the targetDir resolution to properly resolve the path when the child is an absolute path.