### PR TITLE
SLING-11389 Update repoinit parser dependency to latest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.repoinit.parser</artifactId>
-            <version>1.6.14</version>
+            <version>1.7.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.sling</groupId>


### PR DESCRIPTION
With the release of repoinit parser 1.7.0 and repoinit jcr implementation 1.1.40 update the downstream dependencies to make the fix for [SLING-10740](https://issues.apache.org/jira/browse/SLING-10740) available.