### PR TITLE
SLING-11935 - JarDecompressorTest.testWithEmbeddedJar fails on Jenkins/Windows

### DIFF
--- a/src/test/java/org/apache/sling/feature/maven/mojos/JarDecompressorTest.java
+++ b/src/test/java/org/apache/sling/feature/maven/mojos/JarDecompressorTest.java
@@ -16,7 +16,10 @@
  */
 package org.apache.sling.feature.maven.mojos;
 
-import org.junit.Test;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeFalse;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -26,14 +29,13 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.jar.JarEntry;
 import java.util.jar.JarInputStream;
 import java.util.jar.Manifest;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.Test;
 
 public class JarDecompressorTest {
     @Test
@@ -69,6 +71,10 @@ public class JarDecompressorTest {
 
     @Test
     public void testJarWithEmbeddedJar() throws Exception {
+        
+        // SLING-11935 
+        assumeFalse(System.getProperty("os.name").toLowerCase(Locale.ENGLISH).contains("win"));
+        
         File cj = new File(getClass().getResource("/repository/compressed-embedded.jar").getFile());
         File uj = Files.createTempFile(getClass().getSimpleName(), "embedded-uncompressed.jar").toFile();
 


### PR DESCRIPTION
Don't run the problematic test on Windows