### PR TITLE
Use Maven Plugin Tools 3.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,13 +37,13 @@
         <maven.scm.version>1.11.2</maven.scm.version>
         <maven.site.path>${project.artifactId}-archives/${project.artifactId}-LATEST</maven.site.path>
         <project.build.outputTimestamp>1688726872</project.build.outputTimestamp>
+        <sling.feature.version>2.0.0</sling.feature.version>
     </properties>
 
     <scm>
         <connection>scm:git:https://gitbox.apache.org/repos/asf/sling-slingfeature-maven-plugin.git</connection>
         <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/sling-slingfeature-maven-plugin.git</developerConnection>
         <url>https://gitbox.apache.org/repos/asf?p=sling-slingfeature-maven-plugin.git</url>
-      <tag>slingfeature-maven-plugin-1.6.4</tag>
   </scm>
 
     <build>
@@ -64,6 +64,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
+                <version>3.9.0</version>
                 <executions>
                     <execution>
                         <id>mojo-descriptor</id>
@@ -71,6 +72,13 @@
                         <goals>
                             <goal>descriptor</goal>
                         </goals>
+                        <configuration>
+                            <externalJavadocBaseUrls>
+                                <externalJavadocBaseUrl>https://docs.oracle.com/javase/8/docs/api/</externalJavadocBaseUrl>
+                                <externalJavadocBaseUrl>https://www.javadoc.io/doc/org.apache.sling/org.apache.sling.feature/${sling.feature.version}/</externalJavadocBaseUrl>
+                            </externalJavadocBaseUrls>
+                            <internalJavadocBaseUrl>apidocs/</internalJavadocBaseUrl>
+                        </configuration>
                     </execution>
                     <execution>
                         <id>generated-helpmojo</id>
@@ -397,7 +405,11 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-plugin-plugin</artifactId>
+                <artifactId>maven-plugin-report-plugin</artifactId>
+                <version>3.9.0</version>
+                <configuration>
+                    <hasExtensionsToLoad>true</hasExtensionsToLoad>
+                </configuration>
             </plugin>
         </plugins>
     </reporting>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.apache.sling</groupId>
         <artifactId>sling</artifactId>
-        <version>49</version>
+        <version>51</version>
         <relativePath />
     </parent>
 
@@ -64,7 +64,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.9.0</version>
                 <executions>
                     <execution>
                         <id>mojo-descriptor</id>
@@ -74,7 +73,7 @@
                         </goals>
                         <configuration>
                             <externalJavadocBaseUrls>
-                                <externalJavadocBaseUrl>https://docs.oracle.com/javase/8/docs/api/</externalJavadocBaseUrl>
+                                <externalJavadocBaseUrl>https://docs.oracle.com/javase/${sling.java.version}/docs/api/</externalJavadocBaseUrl>
                                 <externalJavadocBaseUrl>https://www.javadoc.io/doc/org.apache.sling/org.apache.sling.feature/${sling.feature.version}/</externalJavadocBaseUrl>
                             </externalJavadocBaseUrls>
                             <internalJavadocBaseUrl>apidocs/</internalJavadocBaseUrl>
@@ -184,7 +183,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.feature</artifactId>
-            <version>2.0.0</version>
+            <version>${sling.feature.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -406,7 +405,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-report-plugin</artifactId>
-                <version>3.9.0</version>
                 <configuration>
                     <hasExtensionsToLoad>true</hasExtensionsToLoad>
                 </configuration>


### PR DESCRIPTION
This adds relevant javadoc links to the generated site for complex parameter types.