### PR TITLE
SLING-11935 fix JarDecompressorTest on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+src/test/resources/repository/textfile.txt eol=lf

--- a/src/test/java/org/apache/sling/feature/maven/mojos/JarDecompressorTest.java
+++ b/src/test/java/org/apache/sling/feature/maven/mojos/JarDecompressorTest.java
@@ -71,10 +71,6 @@ public class JarDecompressorTest {
 
     @Test
     public void testJarWithEmbeddedJar() throws Exception {
-        
-        // SLING-11935 
-        assumeFalse(System.getProperty("os.name").toLowerCase(Locale.ENGLISH).contains("win"));
-        
         File cj = new File(getClass().getResource("/repository/compressed-embedded.jar").getFile());
         File uj = Files.createTempFile(getClass().getSimpleName(), "embedded-uncompressed.jar").toFile();
 
@@ -83,6 +79,7 @@ public class JarDecompressorTest {
 
             Map<String, byte[]> actualJar = readJar(uj);
 
+            // this file is supposed to have *nix line ending
             File tf = new File(getClass().getResource("/repository/textfile.txt").getFile());
             assertEquals(tf.length(), actualJar.get("textfile.txt").length);
             File cf = new File(getClass().getResource("/repository/compressed.jar").getFile());


### PR DESCRIPTION
Always keep *nix line endings for textfile.txt