### PR TITLE
SLING-12127 - Update o.a.s.repoinit.parser to 1.9.0 in slingfeature-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -232,7 +232,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.feature.analyser</artifactId>
-            <version>2.0.0</version>
+            <version>2.0.2</version>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
- update o.a.s.feature.analyzer to 2.0.0 due to its
  transitive dependency to o.a.s.repoinit.parser