### PR TITLE
SLING-12173 - Configuration errors in Eclipse for projects using the slingfeature-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,14 +190,13 @@
         <dependency>
             <groupId>jakarta.json</groupId>
             <artifactId>jakarta.json-api</artifactId>
-            <version>2.0.2</version>
+            <version>2.1.3</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.johnzon</groupId>
-            <artifactId>johnzon-core</artifactId>
-            <classifier>jakarta</classifier>
-            <version>1.2.21</version>
+            <groupId>org.eclipse.parsson</groupId>
+            <artifactId>parsson</artifactId>
+            <version>1.1.5</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/src/it/attach-metadata-from-pom/verify.groovy
+++ b/src/it/attach-metadata-from-pom/verify.groovy
@@ -21,10 +21,10 @@ import java.util.*;
         File file = new File(basedir, "target/slingfeature-tmp/feature-slingtest.json");
         String log = FileUtils.fileRead(file);
          String[] values = [
-            "\"title\":\"Apache Sling Features Maven plugin test\"",
-            "\"description\":\"This is just an Apache Sling Features Maven plugin test to verify added metadata\"",
-            "\"vendor\":\"The Apache Sling Team\"",
-            "\"license\":\"Apache License, Version 2.0\""
+            "\"title\": \"Apache Sling Features Maven plugin test\"",
+            "\"description\": \"This is just an Apache Sling Features Maven plugin test to verify added metadata\"",
+            "\"vendor\": \"The Apache Sling Team\"",
+            "\"license\": \"Apache License, Version 2.0\""
         ];
          for (String value : values) {
             if (log.indexOf(value) < 0) {

--- a/src/it/include-artifact-including-source-features-folder/verify.groovy
+++ b/src/it/include-artifact-including-source-features-folder/verify.groovy
@@ -50,10 +50,10 @@ import org.codehaus.plexus.util.*;
         String dependentArtifact = "janino";
         String dependentVersion = "2.7.5";
         String[] values = [
-            "\"id\":\"" + group + ":" + artifact + ":slingosgifeature:" + classifier + ":" + version + "\"",
-            "\"bundles\":[",
+            "\"id\": \"" + group + ":" + artifact + ":slingosgifeature:" + classifier + ":" + version + "\"",
+            "\"bundles\": [",
             group + ":" + artifact + ":" + version + "\"",
-            "\"repoinit:TEXT|true\":[",
+            "\"repoinit:TEXT|true\": [",
             "\"create path (rep:AuthorizableFolder) /home/users/system\""
         ];
         for (String value : values) {

--- a/src/it/include-artifact-including-source-features/verify.groovy
+++ b/src/it/include-artifact-including-source-features/verify.groovy
@@ -49,10 +49,10 @@ import org.codehaus.plexus.util.*;
         String dependentArtifact = "janino";
         String dependentVersion = "2.7.5";
         String[] values = [
-            "\"id\":\"" + group + ":" + artifact + ":slingosgifeature:" + version + "\"",
-            "\"bundles\":[",
+            "\"id\": \"" + group + ":" + artifact + ":slingosgifeature:" + version + "\"",
+            "\"bundles\": [",
             group + ":" + artifact + ":" + version + "\"",
-            "\"repoinit:TEXT|true\":[",
+            "\"repoinit:TEXT|true\": [",
             "\"create path (rep:AuthorizableFolder) /home/users/system\""
         ];
         for (String value : values) {

--- a/src/it/include-artifact-no-classifier/verify.groovy
+++ b/src/it/include-artifact-no-classifier/verify.groovy
@@ -49,8 +49,8 @@ import org.codehaus.plexus.util.*;
         String dependentArtifact = "janino";
         String dependentVersion = "2.7.5";
         String[] values = [
-            "\"id\":\"" + group + ":" + artifact + ":slingosgifeature:" + version + "\"",
-            "\"bundles\":[",
+            "\"id\": \"" + group + ":" + artifact + ":slingosgifeature:" + version + "\"",
+            "\"bundles\": [",
             group + ":" + artifact + ":" + version + "\"",
             dependentGroup + ":" + dependentArtifact + ":" + dependentVersion + "\"",
         ];

--- a/src/it/include-artifact-simple/verify.groovy
+++ b/src/it/include-artifact-simple/verify.groovy
@@ -50,8 +50,8 @@ import org.codehaus.plexus.util.*;
         String dependentArtifact = "janino";
         String dependentVersion = "2.7.5";
         String[] values = [
-            "\"id\":\"" + group + ":" + artifact + ":slingosgifeature:" + classifier + ":" + version + "\"",
-            "\"bundles\":[",
+            "\"id\": \"" + group + ":" + artifact + ":slingosgifeature:" + classifier + ":" + version + "\"",
+            "\"bundles\": [",
             group + ":" + artifact + ":" + version + "\"",
             dependentGroup + ":" + dependentArtifact + ":" + dependentVersion + "\"",
         ];

--- a/src/it/include-artifact-start-order/verify.groovy
+++ b/src/it/include-artifact-start-order/verify.groovy
@@ -50,10 +50,10 @@ import org.codehaus.plexus.util.*;
         String dependentArtifact = "janino";
         String dependentVersion = "2.7.5";
         String[] values = [
-            "\"id\":\"" + group + ":" + artifact + ":slingosgifeature:" + classifier + ":" + version + "\"",
-            "\"bundles\":[",
+            "\"id\": \"" + group + ":" + artifact + ":slingosgifeature:" + classifier + ":" + version + "\"",
+            "\"bundles\": [",
             group + ":" + artifact + ":" + version + "\"",
-            "\"id\":\"" + dependentGroup + ":" + dependentArtifact + ":" + dependentVersion + "\"",
+            "\"id\": \"" + dependentGroup + ":" + dependentArtifact + ":" + dependentVersion + "\"",
         ];
         for (String value : values) {
             if (fmContent.indexOf(value) < 0) {

--- a/src/it/variables-interpolator/verify.groovy
+++ b/src/it/variables-interpolator/verify.groovy
@@ -25,17 +25,17 @@ import org.codehaus.plexus.util.*;
         String log = FileUtils.fileRead(file);
 
         String[] values = [
-            "\"id\":\"org.apache.sling:slingfeature-maven-plugin-test:slingfeature:slingtest:1.0.0-SNAPSHOT\"",
-            "\"title\":\"Apache Sling Features Maven plugin test\"",
-            "\"description\":\"This is just an Apache Sling Features Maven plugin test to verify variables interpolation\"",
-            "\"vendor\":\"The Apache Software Foundation\"",
+            "\"id\": \"org.apache.sling:slingfeature-maven-plugin-test:slingfeature:slingtest:1.0.0-SNAPSHOT\"",
+            "\"title\": \"Apache Sling Features Maven plugin test\"",
+            "\"description\": \"This is just an Apache Sling Features Maven plugin test to verify variables interpolation\"",
+            "\"vendor\": \"The Apache Software Foundation\"",
             // TODO re-enable verification once license interpolation is fixed
             // "\"license\":\"Apache License, Version 2.0\"",
-            "\"interpolated_variable\":\"true\"",
-            "\"sling.framework.install.incremental\":\"true\"",
-            "\"sling.framework.install.startlevel\":\"1\"",
-            "\"sling.ignoreSystemProperties\":\"true\"",
-            "\"id\":\"org.osgi:org.osgi.framework:1.9.0\""
+            "\"interpolated_variable\": \"true\"",
+            "\"sling.framework.install.incremental\": \"true\"",
+            "\"sling.framework.install.startlevel\": \"1\"",
+            "\"sling.ignoreSystemProperties\": \"true\"",
+            "\"id\": \"org.osgi:org.osgi.framework:1.9.0\""
         ];
 
         for (String value : values) {


### PR DESCRIPTION
Use version 2.1 of the Jakarta JSON APIs. Migrate to Parsson at the same time, since Johnzon does not yet support that API level ( https://issues.apache.org/jira/browse/JOHNZON-389 ).

Some minor whitespace changes were made to the ITs.