### PR TITLE
SLING-12173 - Configuration errors in Eclipse for projects using the slingfeature-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -189,16 +189,9 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>jakarta.json</groupId>
-            <artifactId>jakarta.json-api</artifactId>
-            <version>2.0.2</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.johnzon</groupId>
-            <artifactId>johnzon-core</artifactId>
-            <classifier>jakarta</classifier>
-            <version>1.2.21</version>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.commons.johnzon</artifactId>
+            <version>2.0.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Switch to using the Sling Commons Johnzon implementation for JSON parsing, as it avoids using the ServiceLoader. This should avoid classloading headaches in OSGI environments and have no practical impact in Maven builds.