### PR TITLE
SLING-12305 - Build fails on Java 21 due to invoker plug-in: Unsupported class file major version 65

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,6 +149,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-invoker-plugin</artifactId>
+                <version>3.6.1</version>
                 <configuration>
                     <debug>true</debug>
                     <projectsDirectory>src/it</projectsDirectory>


### PR DESCRIPTION
Update to a more recent version of the invoker-maven-plugin, which depends on a version of Groovy with Java 21 support.