### PR TITLE
Improve Error Handling

### DIFF
--- a/src/main/java/org/apache/sling/feature/maven/mojos/AbstractFeatureMojo.java
+++ b/src/main/java/org/apache/sling/feature/maven/mojos/AbstractFeatureMojo.java
@@ -377,7 +377,7 @@ public abstract class AbstractFeatureMojo extends AbstractMojo {
                     .getOrResolveArtifact(project, mavenSession, artifactHandlerManager, repoSystem, id)
                     .getFile().toURI().toURL();
             } catch (Exception e) {
-                getLog().debug("Artifact " + id.toMvnId() + " not found");
+                getLog().warn("Artifact " + id.toMvnId() + " not found");
                 return null;
             }
         }

--- a/src/main/java/org/apache/sling/feature/maven/mojos/AggregateFeaturesMojo.java
+++ b/src/main/java/org/apache/sling/feature/maven/mojos/AggregateFeaturesMojo.java
@@ -202,7 +202,7 @@ public class AggregateFeaturesMojo extends AbstractIncludingFeatureMojo {
         try {
             return FeatureBuilder.assemble(newFeatureID, builderContext,
                     selection.values().toArray(new Feature[selection.size()]));
-        } catch ( final IllegalStateException | IllegalArgumentException e) {
+        } catch ( final Exception e) {
             throw new MojoExecutionException("Unable to aggregate feature " +
                 (newFeatureID.getClassifier() == null ? "<main artifact>" : newFeatureID.getClassifier())
                 + " : " + e.getMessage(), e);


### PR DESCRIPTION
### Changes:
* If multiple scans have been configured, only the results of the last execution have been considered for the final result calculation
  * Tested locally
  * Before: validation passed
  * After:
   ```
    [ERROR] Analyser detected errors on feature '**'.
    [ERROR] [content-packages-installables] **: Content ** is not resolved and can not be checked.
    [INFO] ------------------------------------------------------------------------
    [INFO] BUILD FAILURE
    [INFO] ------------------------------------------------------------------------
    [INFO] Total time:  6.335 s
    [INFO] Finished at: 2024-08-01T17:35:20+02:00
    [INFO] ------------------------------------------------------------------------
    [ERROR] Failed to execute goal org.apache.sling:slingfeature-maven-plugin:1.8.5-SNAPSHOT:analyse-features (analyze) on project **: One or more feature analyser(s) detected feature error(s), please read the plugin log for more details -> [Help 1]
   ```
* Log warning if an artifact is not found