### PR TITLE
SLING-12596 - JarDecompressorTest.testWithEmbeddedJar fails on Jenkins/Windows after upgrading to Parent 62

### DIFF
--- a/src/test/java/org/apache/sling/feature/maven/mojos/JarDecompressorTest.java
+++ b/src/test/java/org/apache/sling/feature/maven/mojos/JarDecompressorTest.java
@@ -26,6 +26,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.jar.JarEntry;
 import java.util.jar.JarInputStream;
@@ -36,6 +37,7 @@ import org.junit.Test;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeFalse;
 
 public class JarDecompressorTest {
     @Test
@@ -73,6 +75,10 @@ public class JarDecompressorTest {
 
     @Test
     public void testJarWithEmbeddedJar() throws Exception {
+
+        // SLING-12596
+        assumeFalse(System.getProperty("os.name").toLowerCase(Locale.ENGLISH).contains("win"));
+
         File cj = new File(
                 getClass().getResource("/repository/compressed-embedded.jar").getFile());
         File uj = Files.createTempFile(getClass().getSimpleName(), "embedded-uncompressed.jar")


### PR DESCRIPTION
Disable problematic test on Windows