### PR TITLE
SLING-13237: optional OSGi Bundle-SymbolicName collision detection on aggregate

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <maven.scm.version>1.11.2</maven.scm.version>
         <maven.site.path>${project.artifactId}-archives/${project.artifactId}-LATEST</maven.site.path>
         <project.build.outputTimestamp>1771315797</project.build.outputTimestamp>
-        <sling.feature.version>2.0.0</sling.feature.version>
+        <sling.feature.version>2.0.6</sling.feature.version>
     </properties>
 
     <dependencies>

--- a/src/main/java/org/apache/sling/feature/maven/mojos/Aggregate.java
+++ b/src/main/java/org/apache/sling/feature/maven/mojos/Aggregate.java
@@ -74,6 +74,14 @@ public class Aggregate extends FeatureSelectionConfig {
 
     public Map<String, String> frameworkPropertiesOverrides;
 
+    /**
+     * When {@code true}, the aggregated feature is checked for OSGi bundles with
+     * duplicate {@code Bundle-SymbolicName} values and the build fails unless an
+     * {@code artifactsOverrides} rule resolves the collision. Requires
+     * {@code org.apache.sling.feature} 2.0.6 or later.
+     */
+    public boolean osgiBsnCollisionDetection = false;
+
     /* (non-Javadoc)
      * @see java.lang.Object#hashCode()
      */
@@ -89,6 +97,7 @@ public class Aggregate extends FeatureSelectionConfig {
                 frameworkPropertiesOverrides,
                 markAsComplete,
                 markAsFinal,
+                osgiBsnCollisionDetection,
                 title,
                 variablesOverrides,
                 vendor);
@@ -111,6 +120,7 @@ public class Aggregate extends FeatureSelectionConfig {
                 && Objects.equals(frameworkPropertiesOverrides, other.frameworkPropertiesOverrides)
                 && markAsComplete == other.markAsComplete
                 && markAsFinal == other.markAsFinal
+                && osgiBsnCollisionDetection == other.osgiBsnCollisionDetection
                 && Objects.equals(title, other.title)
                 && Objects.equals(variablesOverrides, other.variablesOverrides)
                 && Objects.equals(vendor, other.vendor);
@@ -123,7 +133,7 @@ public class Aggregate extends FeatureSelectionConfig {
                 + ", markAsFinal=" + markAsFinal + ", markAsComplete=" + markAsComplete + ", title=" + title
                 + ", description=" + description + ", vendor=" + vendor + ", artifactsOverrides=" + artifactsOverrides
                 + ", variablesOverrides=" + variablesOverrides + ", frameworkPropertiesOverrides="
-                + frameworkPropertiesOverrides + "]";
+                + frameworkPropertiesOverrides + ", osgiBsnCollisionDetection=" + osgiBsnCollisionDetection + "]";
     }
 
     public List<ArtifactId> getArtifactOverrideRules() {

--- a/src/main/java/org/apache/sling/feature/maven/mojos/AggregateFeaturesMojo.java
+++ b/src/main/java/org/apache/sling/feature/maven/mojos/AggregateFeaturesMojo.java
@@ -146,6 +146,10 @@ public class AggregateFeaturesMojo extends AbstractIncludingFeatureMojo {
                                     false)
                             .toArray(MergeHandler[]::new))
                     .addPostProcessExtensions(postProcessHandlers().toArray(PostProcessHandler[]::new));
+            if (aggregate.osgiBsnCollisionDetection) {
+                builderContext.setOsgiBsnCollisionDetection(true);
+            }
+
             for (final ArtifactId rule : aggregate.getArtifactOverrideRules()) {
                 builderContext.addArtifactsOverride(rule);
             }

--- a/src/test/java/org/apache/sling/feature/maven/mojos/AggregateFeaturesMojoTest.java
+++ b/src/test/java/org/apache/sling/feature/maven/mojos/AggregateFeaturesMojoTest.java
@@ -838,6 +838,20 @@ public class AggregateFeaturesMojoTest {
     }
 
     @Test
+    public void testOsgiBsnCollisionDetectionFlagPropagates() throws Exception {
+        TestContext ctx = prepareTestContext("/aggregate-features/dir2", new String[] {"test_w.json"});
+
+        ctx.getMojo().aggregates.get(0).osgiBsnCollisionDetection = true;
+
+        // The assembly must succeed when there are no BSN collisions even with detection on.
+        // (Negative case — collision raises an exception — is covered in the feature-core unit tests
+        // for OsgiBsnDeduplicator; aggregating live OSGi bundles here would require a heavier fixture.)
+        ctx.getMojo().execute();
+        Feature genFeat = ctx.getFeatureMap().get(":aggregate:aggregated:T");
+        assertNotNull(genFeat);
+    }
+
+    @Test
     public void customAggregate() throws Exception {
 
         TestContext ctx = prepareTestContext(


### PR DESCRIPTION
## What

Adds an `osgiBsnCollisionDetection` flag to the `<aggregate>` configuration. When enabled, the aggregated feature is checked for OSGi bundles with duplicate `Bundle-SymbolicName` values, and the build fails unless an `artifactsOverrides` rule resolves the collision.

This requires `org.apache.sling.feature` 2.0.6 (for `BuilderContext.setOsgiBsnCollisionDetection`), so `sling.feature.version` is bumped from 2.0.0 to 2.0.6.

## Why

Split out from #100 per review feedback — BSN collision detection (and its dependency bump) is logically separate from the `additionalFeatureFiles` change and is tracked under its own issue, SLING-13237.

## Notes

The test covers the positive path (assembly succeeds with detection on and no collisions); the collision-raises-an-exception case is covered by the feature-core unit tests for the underlying deduplicator.