### PR TITLE
SLING-13239 - apis-jar javadoc generation fails on Java 25 due to unexpected files

### DIFF
--- a/src/main/java/org/apache/sling/feature/maven/mojos/ApisJarMojo.java
+++ b/src/main/java/org/apache/sling/feature/maven/mojos/ApisJarMojo.java
@@ -805,6 +805,9 @@ public class ApisJarMojo extends AbstractIncludingFeatureMojo {
                     "jquery.jszip-utils.dist",
                     "jquery.jszip.dist",
                     "resources",
+                    "resource-files",
+                    "resource-files.fonts",
+                    "script-files",
                     "legal");
             apiPackages.removeAll(jqueryPackages);
         }


### PR DESCRIPTION
Add new files to exclude.